### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage of ./go-webring
   -v, --validationlog string   Path to validation log, see docs for requirements (default "validation.log")
 ```
 
-This webring implementation handles four paths:
+This webring implementation handles five paths:
 - **Root:** returns the home page template replacing the string "`{{ . }}`" with
   an HTML table of ring members
 - **Next:** returns a 302 redirect pointing to the next site in the list
@@ -36,6 +36,8 @@ This webring implementation handles four paths:
   specified in the command line flags
   - For example, with `-v validationlog -h example.com`, the path would be
     `example.com/validationlog`
+- **Healthcheck:** returns a 204 (no content) response, which can be used to
+  check whether the webring is up.
 
 The **next** and **previous** paths require a `?host=` parameter containing a
 URL-encoded URI of the site being visited. For example, if Sam is a member of a

--- a/handlers.go
+++ b/handlers.go
@@ -134,3 +134,7 @@ func (m model) notFound(writer http.ResponseWriter, request *http.Request) {
 		writer.Write([]byte(*m.notFoundHtml))
 	}
 }
+
+func (m model) healthCheck(writer http.ResponseWriter, request *http.Request) {
+	writer.WriteHeader(http.StatusNoContent)
+}

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func main() {
 	mux.HandleFunc("/previous", m.previous)
 	mux.HandleFunc("/random", m.random)
 	mux.HandleFunc("/"+filepath.Base(*flagValidationLog), m.validationLog)
+	mux.HandleFunc("/healthcheck", m.healthCheck)
 
 	fileHandler := http.StripPrefix("/static/", http.FileServer(http.Dir("static")))
 	mux.Handle("/static/", fileHandler)


### PR DESCRIPTION
Adds a `/healthcheck` URL endpoint which responds with a 204 (No Content) response.
Designed to be used for people who want to include JavaScript in their sites to check if the webring is active and show/hide the webring links based on the response.