### PR TITLE
Fancy error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tera = "1.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.15", features = ["io"] }
-tower-http = { version = "0.6.4", features = ["cors", "fs"] }
+tower-http = { version = "0.6.4", features = ["cors", "fs", "catch-panic"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -38,9 +38,13 @@ pub fn create_router(cli: &CliOptions) -> Router<&'static Webring> {
 }
 
 fn create_error_template() -> Tera {
-    let template_src = include_str!("templates/error.html");
+    let html_src = include_str!("templates/error.html");
+    let css_src = include_str!("templates/error.css");
     let mut tera = Tera::default();
-    tera.add_raw_template("error.html", template_src).unwrap();
+    tera.add_raw_templates(vec![
+        ("error.html", html_src),
+        ("error.css", css_src),
+    ]).unwrap();
     tera
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,21 +1,29 @@
 //! Routes and endpoints
 
-use std::{collections::HashMap, str::FromStr};
+use std::{
+    collections::HashMap, error::Error, fmt::Display, fmt::Write, str::FromStr, sync::LazyLock,
+};
 
 use axum::{
     Router,
     extract::{Query, State},
-    http::{HeaderMap, Uri},
+    http::{HeaderMap, Uri, uri::InvalidUri},
     response::{Html, IntoResponse, NoContent, Redirect, Response},
     routing::get,
 };
 use reqwest::StatusCode;
+use tera::Tera;
 use tower_http::{
     cors::{Any, CorsLayer},
     services::ServeDir,
 };
 
-use crate::{CliOptions, webring::Webring};
+use crate::{
+    CliOptions,
+    webring::{TraverseWebringError, Webring},
+};
+
+static ERROR_TEMPLATE: LazyLock<Tera> = LazyLock::new(create_error_template);
 
 /// Creates a [`Router`] with the routes for our application.
 pub fn create_router(cli: &CliOptions) -> Router<&'static Webring> {
@@ -33,7 +41,14 @@ pub fn create_router(cli: &CliOptions) -> Router<&'static Webring> {
         .route("/random", get(serve_random))
 }
 
-async fn serve_index(State(webring): State<&Webring>) -> Result<Response, HomepageError> {
+fn create_error_template() -> Tera {
+    let template_src = include_str!("templates/error.html");
+    let mut tera = Tera::default();
+    tera.add_raw_template("error.html", template_src).unwrap();
+    tera
+}
+
+async fn serve_index(State(webring): State<&Webring>) -> Result<Response, RouteError> {
     Ok(Html(webring.homepage().await?.to_html().to_owned()).into_response())
 }
 
@@ -49,13 +64,10 @@ async fn serve_next(
     State(webring): State<&Webring>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<Redirect, Response> {
-    let origin = get_origin_from_request(&headers, &params)?;
-    // FIXME: Differentiate between origin not found and all sites failing checks
-    match webring.next_page(&origin).ok() {
-        Some(page) => Ok(Redirect::to(page.to_string().as_str())),
-        None => Err((StatusCode::SERVICE_UNAVAILABLE, "No suitable sites found").into_response()),
-    }
+) -> Result<Redirect, RouteError> {
+    let origin = get_origin_from_request(headers, params)?;
+    let page = webring.next_page(&origin)?;
+    Ok(Redirect::to(page.to_string().as_str()))
 }
 
 /// Serve the `/previous` and `/prev` endpoints.
@@ -70,13 +82,10 @@ async fn serve_previous(
     State(webring): State<&Webring>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<Redirect, Response> {
-    let origin = get_origin_from_request(&headers, &params)?;
-    // FIXME: Differentiate between origin not found and all sites failing checks
-    match webring.prev_page(&origin).ok() {
-        Some(page) => Ok(Redirect::to(page.to_string().as_str())),
-        None => Err((StatusCode::SERVICE_UNAVAILABLE, "No suitable sites found").into_response()),
-    }
+) -> Result<Redirect, RouteError> {
+    let origin = get_origin_from_request(headers, params)?;
+    let page = webring.prev_page(&origin)?;
+    Ok(Redirect::to(page.to_string().as_str()))
 }
 
 /// Serve the `/random` endpoint.
@@ -91,12 +100,10 @@ async fn serve_random(
     State(webring): State<&Webring>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<Redirect, Response> {
-    let maybe_origin = get_origin_from_request(&headers, &params).ok();
-    match webring.random_page(maybe_origin.as_ref()) {
-        Some(page) => Ok(Redirect::to(page.to_string().as_str())),
-        None => Err((StatusCode::SERVICE_UNAVAILABLE, "No suitable sites found").into_response()),
-    }
+) -> Result<Redirect, RouteError> {
+    let maybe_origin = get_origin_from_request(headers, params).ok();
+    let page = webring.random_page(maybe_origin.as_ref())?;
+    Ok(Redirect::to(page.to_string().as_str()))
 }
 
 /// Get a URI representing the origin of the request.
@@ -106,56 +113,143 @@ async fn serve_random(
 /// the found URI fails, an `Err` is returned with a [`Response`] suitable for returning to the
 /// client.
 fn get_origin_from_request(
-    headers: &HeaderMap,
-    params: &HashMap<String, String>,
-) -> Result<Uri, Response> {
-    match params.get("host") {
-        Some(host) => match Uri::from_str(host) {
+    mut headers: HeaderMap,
+    mut params: HashMap<String, String>,
+) -> Result<Uri, RouteError> {
+    match params.remove("host") {
+        Some(host) => match Uri::from_str(&host) {
             Ok(uri) => Ok(uri),
-            Err(err) => Err((
-                StatusCode::BAD_REQUEST,
-                format!("host query parameter contains invalid URI: {err}"),
-            )
-                .into_response()),
+            Err(err) => Err(RouteError::InvalidOriginURI {
+                uri: host,
+                reason: err,
+                place: OriginUriLocation::HostQueryParam,
+            }),
         },
-        None => match headers.get("referer") {
+        None => match headers.remove("referer") {
             Some(referer) => match referer.to_str() {
                 Ok(referer_str) => match Uri::from_str(referer_str) {
                     Ok(uri) => Ok(uri),
-                    Err(err) => Err((
-                        StatusCode::BAD_REQUEST,
-                        format!("Invalid Referer URI: {err}"),
-                    )
-                        .into_response()),
+                    Err(err) => Err(RouteError::InvalidOriginURI {
+                        uri: referer_str.to_owned(),
+                        reason: err,
+                        place: OriginUriLocation::RefererHeader,
+                    }),
                 },
-                Err(err) => Err((
-                    StatusCode::BAD_REQUEST,
-                    format!("Error parsing Referer URI: {err}"),
-                )
-                    .into_response()),
+                Err(_) => Err(RouteError::HeaderToStr(OriginUriLocation::RefererHeader)),
             },
-            None => Err((
-                StatusCode::BAD_REQUEST,
-                "Missing Referer header and ?host= parameter",
-            )
-                .into_response()),
+            None => Err(RouteError::MissingOriginURI),
         },
     }
 }
 
-#[derive(Debug)]
-struct HomepageError(eyre::Report);
-impl From<eyre::Report> for HomepageError {
-    fn from(value: eyre::Report) -> Self {
-        Self(value)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+enum OriginUriLocation {
+    RefererHeader,
+    HostQueryParam,
+}
+
+impl Display for OriginUriLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OriginUriLocation::RefererHeader => "Referer header",
+            OriginUriLocation::HostQueryParam => "?host= query parameter",
+        }
+        .fmt(f)
     }
 }
-impl IntoResponse for HomepageError {
+
+#[derive(Debug, thiserror::Error)]
+enum RouteError {
+    #[error(r#"Origin URI "{uri}" found in {place} is invalid: {reason}"#)]
+    InvalidOriginURI {
+        uri: String,
+        #[source]
+        reason: InvalidUri,
+        place: OriginUriLocation,
+    },
+
+    #[error("Request doesn't indicate which site it originates from.")]
+    MissingOriginURI,
+
+    #[error("{0} contains data which is not valid UTF-8")]
+    HeaderToStr(OriginUriLocation),
+
+    #[error("Error traversing webring: {0}")]
+    Traversal(
+        #[from]
+        #[source]
+        TraverseWebringError,
+    ),
+
+    #[error("Error rendering homepage: {0}")]
+    RenderHomepage(
+        #[from]
+        #[source]
+        eyre::Report,
+    ),
+}
+
+impl IntoResponse for RouteError {
     fn into_response(self) -> axum::response::Response {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error rendering home page: {}", self.0),
-        )
-            .into_response()
+        let status = match &self {
+            RouteError::Traversal(TraverseWebringError::AllMembersFailing) => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            RouteError::Traversal(
+                TraverseWebringError::NoAuthority(_) | TraverseWebringError::AuthorityNotFound(_),
+            )
+            | RouteError::InvalidOriginURI { .. }
+            | RouteError::MissingOriginURI
+            | RouteError::HeaderToStr(_) => StatusCode::BAD_REQUEST,
+            RouteError::RenderHomepage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let mut context = tera::Context::new();
+        context.insert("status_code", &status.as_u16());
+        context.insert(
+            "status_text",
+            status.canonical_reason().unwrap_or("Unknown Error"),
+        );
+        context.insert(
+            "description",
+            match status {
+                StatusCode::BAD_REQUEST => "The request we received wasn't quite right.",
+                StatusCode::SERVICE_UNAVAILABLE => "We couldn't find a site to route you to.",
+                StatusCode::INTERNAL_SERVER_ERROR => "Something unexpected went wrong.",
+                _ => "We're not quite sure.",
+            },
+        );
+
+        // Render error and chain
+        let mut error_explanation = format!("{}", &self);
+        let mut source = self.source();
+        while let Some(error) = source {
+            write!(&mut error_explanation, "\nCaused by: {error}").unwrap();
+            source = error.source();
+        }
+        context.insert("error", &error_explanation);
+
+        // We can unwrap this because the template is compiled into the program, so we know it'll
+        // render properly. The test_render_error_template() unit test ensures this succeeds.
+        let html = ERROR_TEMPLATE.render("error.html", &context).unwrap();
+        (status, Html(html)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use axum::{http::Uri, response::IntoResponse};
+
+    #[test]
+    fn test_render_error_template() {
+        let bad_uri = "http:\\\\back.slash\\woah\\there";
+        let error = super::RouteError::InvalidOriginURI {
+            uri: bad_uri.to_string(),
+            reason: Uri::from_str(bad_uri).unwrap_err(),
+            place: super::OriginUriLocation::RefererHeader,
+        };
+        // We just want this to not panic
+        let _ = error.into_response();
     }
 }

--- a/src/templates/error.css
+++ b/src/templates/error.css
@@ -2,12 +2,18 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, avenir next,
         avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto,
         noto, helvetica, arial, sans-serif;
-    margin: 24px;
+    margin: 0;
+    padding: 24px;
     color: #262426; /* From logo color */
+    width: fit-content;
+    min-width: 100%;
+    box-sizing: border-box;
 }
+
 h1, h2 {
     margin: 0;
 }
+
 h1 {
     font-size: 64pt;
     font-weight: 950; /* Extra Black */
@@ -17,31 +23,42 @@ h1 {
     align-items: center;
     gap: 0 0.3em;
 }
+
 h1 svg {
     height: 0.8em;
     flex: 0 0 auto;
 }
+
 h2 {
     font-size: 40pt;
-    font-weight: 700; /* Bold */
+    font-weight: 800; /* Heavy */
 }
+
+p, summary {
+    font-weight: 300;
+}
+
 #title-block {
     margin-bottom: 48px;
 }
+
 code {
     font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida
         Console, monospace;
     color: #cb4335;
 }
+
 a:link {
     color: #2874a6;
 }
+
 details > summary {
     cursor: pointer;
 }
+
 @media (min-width: 640px) {
     body {
-        margin: 32px;
+        padding: 32px;
     }
     h1 {
         font-size: 128pt;
@@ -50,8 +67,9 @@ details > summary {
         font-size: 48pt;
     }
 }
+
 @media (min-width: 768px) {
     body {
-        margin: 64px;
+        padding: 64px;
     }
 }

--- a/src/templates/error.css
+++ b/src/templates/error.css
@@ -1,0 +1,57 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, avenir next,
+        avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto,
+        noto, helvetica, arial, sans-serif;
+    margin: 24px;
+    color: #262426; /* From logo color */
+}
+h1, h2 {
+    margin: 0;
+}
+h1 {
+    font-size: 64pt;
+    font-weight: 950; /* Extra Black */
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0 0.3em;
+}
+h1 svg {
+    height: 0.8em;
+    flex: 0 0 auto;
+}
+h2 {
+    font-size: 40pt;
+    font-weight: 700; /* Bold */
+}
+#title-block {
+    margin-bottom: 48px;
+}
+code {
+    font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida
+        Console, monospace;
+    color: #cb4335;
+}
+a:link {
+    color: #2874a6;
+}
+details > summary {
+    cursor: pointer;
+}
+@media (min-width: 640px) {
+    body {
+        margin: 32px;
+    }
+    h1 {
+        font-size: 128pt;
+    }
+    h2 {
+        font-size: 48pt;
+    }
+}
+@media (min-width: 768px) {
+    body {
+        margin: 64px;
+    }
+}

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Internal Server Error — Purdue Hackers webring</title>
+        <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, avenir next,
+                avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto,
+                noto, helvetica, arial, sans-serif;
+            margin: 24px;
+            color: #262426; /* From logo color */
+        }
+        h1, h2 {
+            margin: 0;
+        }
+        h1 {
+            font-size: 64pt;
+            font-weight: 950; /* Extra Black */
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0 0.3em;
+        }
+        h1 svg {
+            height: 0.8em;
+            flex: 0 0 auto;
+        }
+        h2 {
+            font-size: 40pt;
+            font-weight: 700; /* Bold */
+        }
+        #title-block {
+            margin-bottom: 48px;
+        }
+        code {
+            font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida
+                Console, monospace;
+            color: #cb4335;
+        }
+        @media (min-width: 640px) {
+            body {
+                margin: 32px;
+            }
+            h1 {
+                font-size: 128pt;
+            }
+            h2 {
+                font-size: 48pt;
+            }
+        }
+        @media (min-width: 768px) {
+            body {
+                margin: 64px;
+            }
+        }
+        </style>
+    </head>
+    <body>
+        <div id="title-block">
+            <h1>
+                <svg viewBox="0 0 139 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_289_155)">
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M34.7939 21.245L69.3421 41.3744L102.81 21.8414L102.915 62.5L106.852 59.7568V21.5677L139 41.9848L138.888 120.11L105.182 138.948L105.147 98.0721L69.3351 118.903V160.278L34.6395 180.007L0 159.899L0.126319 121.169L35.3202 141.348L35.3693 136.893L2.0983 117.605L34.836 99.5455L34.7939 21.245Z" fill="#262426"/>
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M101.574 104.197C101.574 104.197 101.603 104.19 101.617 104.197C101.631 104.204 101.638 104.218 101.638 104.232L101.932 137.222V104.302L73.3071 120.776L101.638 104.19L101.68 137.222L73.244 120.776" fill="#262426"/>
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M69.3491 37.0665L37.4466 18.4806L69.3281 0L101.21 18.4736L69.3421 37.0735L69.3491 37.0665Z" fill="#262426"/>
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M106.957 21.708L138.993 41.9848L106.845 59.7778L106.95 21.708H106.957Z" fill="#262426"/>
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M34.8781 99.4403L69.3281 118.91L35.3763 136.886L2.0983 117.605L34.8781 99.4403Z" fill="#262426"/>
+                    </g>
+                    <defs>
+                        <clipPath id="clip0_289_155">
+                            <rect width="139" height="180" fill="white"/>
+                        </clipPath>
+                    </defs>
+                </svg>
+                <span>{{ status_code }}</span>
+            </h1>
+            <h2>{{ status_text }}</h2>
+        </div>
+
+        <div>
+            <h3>What happened?</h3>
+            <p>
+                {{ description }}
+            </p>
+            <h4>Reason</h4>
+            <p>
+            <pre><code>{{ error }}</code></pre>
+            </p>
+        </div>
+    </body>
+</html>

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -3,65 +3,7 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Internal Server Error — Purdue Hackers webring</title>
-        <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, avenir next,
-                avenir, segoe ui, helvetica neue, Cantarell, Ubuntu, roboto,
-                noto, helvetica, arial, sans-serif;
-            margin: 24px;
-            color: #262426; /* From logo color */
-        }
-        h1, h2 {
-            margin: 0;
-        }
-        h1 {
-            font-size: 64pt;
-            font-weight: 950; /* Extra Black */
-            display: flex;
-            flex-direction: row;
-            flex-wrap: wrap;
-            align-items: center;
-            gap: 0 0.3em;
-        }
-        h1 svg {
-            height: 0.8em;
-            flex: 0 0 auto;
-        }
-        h2 {
-            font-size: 40pt;
-            font-weight: 700; /* Bold */
-        }
-        #title-block {
-            margin-bottom: 48px;
-        }
-        code {
-            font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida
-                Console, monospace;
-            color: #cb4335;
-        }
-        a:link {
-            color: #2874a6;
-        }
-        details > summary {
-            cursor: pointer;
-        }
-        @media (min-width: 640px) {
-            body {
-                margin: 32px;
-            }
-            h1 {
-                font-size: 128pt;
-            }
-            h2 {
-                font-size: 48pt;
-            }
-        }
-        @media (min-width: 768px) {
-            body {
-                margin: 64px;
-            }
-        }
-        </style>
+        <style>{% include "error.css" %}</style>
     </head>
     <body>
         <div id="title-block">

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -66,7 +66,7 @@ E.g.: Which path did you visit (`/`, `/next`, `/random`, etc.)? Which site did y
 ```
 " ~ error ~ "
 ```" %}
-                <a href="{{ cargo_pkg_repository }}/issues/new?labels=bug&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}"
+                <a href="{{ cargo_pkg_repository }}/issues/new?labels=bug,auto%20generated&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}"
                     >opening an issue on GitHub</a>.
             </p>
         </div>

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Internal Server Error — Purdue Hackers webring</title>
+        <title>{{ status_code }} {{ status_text }} — Purdue Hackers webring</title>
         <style>{% include "error.css" %}</style>
     </head>
     <body>

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -42,6 +42,9 @@
         a:link {
             color: #2874a6;
         }
+        details > summary {
+            cursor: pointer;
+        }
         @media (min-width: 640px) {
             body {
                 margin: 32px;
@@ -89,7 +92,16 @@
             </p>
             <h4>Reason</h4>
             <p>
-            <pre><code>{{ error }}</code></pre>
+            {%- set n_lines = (error | split(pat="
+") | length) -%}
+            {% if n_lines > 5 -%}
+            <details>
+                <summary>Expand error message</summary>
+            {%- endif %}
+                <pre><code>{{ error }}</code></pre>
+            {% if n_lines > 5 -%}
+            </details>
+            {%- endif %}
             </p>
         </div>
 

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -56,6 +56,12 @@
                 We might not realize there's a problem.<br>
                 Please let us know by
                 {%- set title = "Bug report: " ~ status_code ~ " " ~ status_text -%}
+                {%- set error_bytes = error | urlencode_strict | length -%}
+                {%- if error_bytes > 4096 -%}
+                {%- set issue_code = 'Copy and paste the error message from the "Reason" section of the error page here' -%}
+                {%- else -%}
+                {%- set issue_code = error -%}
+                {%- endif -%}
                 {%- set body = "# Description
 
 Describe what you did that resulted in this error.
@@ -64,9 +70,11 @@ E.g.: Which path did you visit (`/`, `/next`, `/random`, etc.)? Which site did y
 # Error
 
 ```
-" ~ error ~ "
+" ~ issue_code ~ "
 ```" %}
-                <a href="{{ cargo_pkg_repository }}/issues/new?labels=bug,auto%20generated&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}"
+                <a
+                    target="_blank"
+                    href="{{ cargo_pkg_repository }}/issues/new?labels=bug,auto%20generated&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}"
                     >opening an issue on GitHub</a>.
             </p>
         </div>

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -33,18 +33,20 @@
                 {{ description }}
             </p>
             <h4>Reason</h4>
-            <p>
             {%- set n_lines = (error | split(pat="
 ") | length) -%}
             {% if n_lines > 5 -%}
             <details>
                 <summary>Expand error message</summary>
+            {%- else -%}
+            <p>
             {%- endif %}
                 <pre><code>{{ error }}</code></pre>
             {% if n_lines > 5 -%}
             </details>
-            {%- endif %}
+            {%- else -%}
             </p>
+            {%- endif %}
         </div>
 
         {% if status_code >= 500 and status_code < 600 -%}
@@ -63,9 +65,9 @@ E.g.: Which path did you visit (`/`, `/next`, `/random`, etc.)? Which site did y
 
 ```
 " ~ error ~ "
-```" -%}
-                <a href="{{ cargo_pkg_repository }}/issues/new?labels=bug&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}">
-                    opening an issue on GitHub</a>.
+```" %}
+                <a href="{{ cargo_pkg_repository }}/issues/new?labels=bug&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}"
+                    >opening an issue on GitHub</a>.
             </p>
         </div>
         {%- endif %}

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -39,6 +39,9 @@
                 Console, monospace;
             color: #cb4335;
         }
+        a:link {
+            color: #2874a6;
+        }
         @media (min-width: 640px) {
             body {
                 margin: 32px;
@@ -89,5 +92,28 @@
             <pre><code>{{ error }}</code></pre>
             </p>
         </div>
+
+        {% if status_code >= 500 and status_code < 600 -%}
+        <div>
+            <h3>Report this error</h3>
+            <p>
+                We might not realize there's a problem.<br>
+                Please let us know by
+                {%- set title = "Bug report: " ~ status_code ~ " " ~ status_text -%}
+                {%- set body = "# Description
+
+Describe what you did that resulted in this error.
+E.g.: Which path did you visit (`/`, `/next`, `/random`, etc.)? Which site did you come from?
+
+# Error
+
+```
+" ~ error ~ "
+```" -%}
+                <a href="{{ cargo_pkg_repository }}/issues/new?labels=bug&title={{ title | urlencode_strict }}&body={{ body | urlencode_strict }}">
+                    opening an issue on GitHub</a>.
+            </p>
+        </div>
+        {%- endif %}
     </body>
 </html>


### PR DESCRIPTION
Implements user-friendly and (in my opinion) nice-looking error handling.

Example of an HTTP 500 error page returned when the `index.html` template can't be rendered:
![image](https://github.com/user-attachments/assets/927f5437-48a0-4fd7-b8fe-43453e9c1c9c)


Example of long error message hidden behind dropdown:
![image](https://github.com/user-attachments/assets/e2e405b8-7946-4458-863d-6607793c2e67)



# To do

- [x] Automatically turn panics in to 500 errors
- [x] Add contact/issue reporting information