### PR TITLE
Reload webring when members file changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
     path::PathBuf,
     process::ExitCode,
     sync::Arc,
+    time::Duration,
 };
 
 use clap::{Parser, ValueEnum};
@@ -113,7 +114,13 @@ async fn main() -> ExitCode {
     }
 
     // Create webring data structure
-    let webring = match Webring::new(cli.members_file.clone(), cli.static_dir.clone()).await {
+    let webring = match Webring::new(
+        cli.members_file.clone(),
+        cli.static_dir.clone(),
+        Duration::from_secs(60),
+    )
+    .await
+    {
         Ok(w) => w,
         Err(err) => {
             error!("Failed to create webring: {err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{
     net::SocketAddr,
     path::PathBuf,
     process::ExitCode,
+    sync::Arc,
 };
 
 use clap::{Parser, ValueEnum};
@@ -112,12 +113,7 @@ async fn main() -> ExitCode {
     }
 
     // Create webring data structure
-    let webring = match Webring::new(
-        cli.members_file.clone(),
-        cli.static_dir.clone(),
-    )
-    .await
-    {
+    let webring = match Webring::new(cli.members_file.clone(), cli.static_dir.clone()).await {
         Ok(w) => w,
         Err(err) => {
             error!("Failed to create webring: {err}");
@@ -126,7 +122,7 @@ async fn main() -> ExitCode {
     };
 
     // Start server
-    let router = create_router(&cli).with_state(webring);
+    let router = create_router(&cli).with_state(Arc::new(webring));
     let bind_addr = &cli.listen_addr;
     match tokio::net::TcpListener::bind(bind_addr).await {
         // Unwrapping this is fine because it will never resolve

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -86,6 +86,7 @@ fn create_error_template() -> Tera {
 }
 
 async fn serve_index(State(webring): State<Arc<Webring>>) -> Result<Response, RouteError> {
+    webring.try_update().await;
     Ok(Html(webring.homepage().await?.to_html().to_owned()).into_response())
 }
 
@@ -103,7 +104,8 @@ async fn serve_next(
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Redirect, RouteError> {
     let origin = get_origin_from_request(headers, params)?;
-    let page = webring.next_page(&origin).await?;
+    webring.try_update().await;
+    let page = webring.next_page(&origin)?;
     Ok(Redirect::to(page.to_string().as_str()))
 }
 
@@ -121,7 +123,8 @@ async fn serve_previous(
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Redirect, RouteError> {
     let origin = get_origin_from_request(headers, params)?;
-    let page = webring.prev_page(&origin).await?;
+    webring.try_update().await;
+    let page = webring.prev_page(&origin)?;
     Ok(Redirect::to(page.to_string().as_str()))
 }
 
@@ -139,7 +142,8 @@ async fn serve_random(
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Redirect, RouteError> {
     let maybe_origin = get_origin_from_request(headers, params).ok();
-    let page = webring.random_page(maybe_origin.as_ref()).await?;
+    webring.try_update().await;
+    let page = webring.random_page(maybe_origin.as_ref())?;
     Ok(Redirect::to(page.to_string().as_str()))
 }
 

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -33,6 +33,7 @@ pub enum CheckLevel {
 struct Member {
     name: String,
     website: Arc<Uri>,
+    #[allow(dead_code)] // FIXME: Remove once Discord integration is implemented
     discord_id: String,
     check_level: CheckLevel,
     check_successful: Arc<AtomicBool>,
@@ -410,7 +411,6 @@ pub enum TraverseWebringError {
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        io::Write,
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},


### PR DESCRIPTION
Closes #6.

The member file's modification timestamp will be checked each time the webring is accessed, and if it has changed, it will be reloaded.

This also changes `Webring::new()` to not create a leaked static singleton and to instead return an owned `Webring`.

# To do
- [x] Add some debounce, so the file only gets accessed e.g. once per minute to check the timestamp. We don't want to require every request to have to do file I/O.