### PR TITLE
Reload webring data when relevant files are changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -463,6 +469,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -655,7 +682,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "ignore",
  "walkdir",
 ]
@@ -1011,6 +1038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1086,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1122,17 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1128,6 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -1154,6 +1233,31 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.9.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-traits"
@@ -1185,7 +1289,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1319,6 +1423,7 @@ dependencies = [
  "futures",
  "html-escape",
  "log",
+ "notify",
  "pretty_assertions",
  "quick-xml",
  "rand 0.9.1",
@@ -1558,7 +1663,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1662,7 +1767,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1753,7 +1858,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1953,7 +2058,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2135,7 +2240,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "bytes",
  "futures-util",
  "http",
@@ -2693,7 +2798,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "quick-xml",
  "rand 0.9.1",
  "reqwest",
+ "same-file",
  "serde",
  "surge-ping",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ notify = "8.0.0"
 quick-xml = { version = "0.37.5", features = ["async-tokio"] }
 rand = "0.9.1"
 reqwest = { version = "0.12.15", features = ["stream"] }
+same-file = "1.0.6"
 serde = { version = "1.0.219", features = ["derive"] }
 surge-ping = "0.8.2"
 tera = "1.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ftail = "0.3.0"
 futures = "0.3.31"
 html-escape = "0.2.13"
 log = "0.4.27"
+notify = "8.0.0"
 quick-xml = { version = "0.37.5", features = ["async-tokio"] }
 rand = "0.9.1"
 reqwest = { version = "0.12.15", features = ["stream"] }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,11 @@
 //! Routes and endpoints
 
 use std::{
-    collections::HashMap, error::Error, fmt::Display, fmt::Write, str::FromStr, sync::LazyLock,
+    collections::HashMap,
+    error::Error,
+    fmt::{Display, Write},
+    str::FromStr,
+    sync::{Arc, LazyLock},
 };
 
 use axum::{
@@ -30,7 +34,7 @@ use crate::{
 static ERROR_TEMPLATE: LazyLock<Tera> = LazyLock::new(create_error_template);
 
 /// Creates a [`Router`] with the routes for our application.
-pub fn create_router(cli: &CliOptions) -> Router<&'static Webring> {
+pub fn create_router(cli: &CliOptions) -> Router<Arc<Webring>> {
     let mut router = Router::new()
         .nest_service(
             "/static",
@@ -81,7 +85,7 @@ fn create_error_template() -> Tera {
     tera
 }
 
-async fn serve_index(State(webring): State<&Webring>) -> Result<Response, RouteError> {
+async fn serve_index(State(webring): State<Arc<Webring>>) -> Result<Response, RouteError> {
     Ok(Html(webring.homepage().await?.to_html().to_owned()).into_response())
 }
 
@@ -94,7 +98,7 @@ async fn serve_index(State(webring): State<&Webring>) -> Result<Response, RouteE
 ///
 /// If finding the next site fails, an HTTP 502 (Service Unavailable) response is sent.
 async fn serve_next(
-    State(webring): State<&Webring>,
+    State(webring): State<Arc<Webring>>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Redirect, RouteError> {
@@ -112,7 +116,7 @@ async fn serve_next(
 ///
 /// If finding the previous site fails, an HTTP 502 (Service Unavailable) response is sent.
 async fn serve_previous(
-    State(webring): State<&Webring>,
+    State(webring): State<Arc<Webring>>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Redirect, RouteError> {
@@ -130,7 +134,7 @@ async fn serve_previous(
 ///
 /// If finding a random site fails, an HTTP 502 (Service Unavailable) response is sent.
 async fn serve_random(
-    State(webring): State<&Webring>,
+    State(webring): State<Arc<Webring>>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Redirect, RouteError> {

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -282,25 +282,23 @@ impl Webring {
     }
 
     /// Enable automatic reloading of the webring's data when its members file changes.
-    ///
-    /// This will keep at least one additional reference to `self`, with a lifetime of `'static`.
-    /// I.e., calling this method will cause the given webring to live forever.
     pub fn enable_reloading(self: &Arc<Self>) -> eyre::Result<()> {
-        // FIXME: This creates a reference cycle, so the given webring will be leaked
-
         // We need to use a channel to send events, because notify runs the watcher in its own thread
         // which is not part of the tokio runtime. So we can't run `webring.update_from_file()` in the
         // closure because that is async and requires an async runtime. Thus we use the channel to
         // notify an async task that the file should be reloaded.
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        let self_for_closure = Arc::clone(self);
+        let self_for_closure = Arc::downgrade(self);
         let mut watcher =
             notify::recommended_watcher(move |maybe_event: notify::Result<notify::Event>| {
+                // We can upgrade because if the webring was dropped, this watcher would be
+                // deregistered and thus we wouldn't be here.
+                let webring = self_for_closure.upgrade().unwrap();
                 match maybe_event {
                     Ok(event) => {
                         debug!(
                             "Event observed on {}: {event:#?}",
-                            self_for_closure.members_file_path.display()
+                            webring.members_file_path.display()
                         );
                         if !matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
                             return;
@@ -308,7 +306,7 @@ impl Webring {
 
                         info!(
                             "Detected change to {}. Reloading webring.",
-                            self_for_closure.members_file_path.display()
+                            webring.members_file_path.display()
                         );
                         tx.blocking_send(()).unwrap();
                     }
@@ -317,10 +315,12 @@ impl Webring {
                     }
                 }
             })?;
-        let self_for_task = Arc::clone(self);
+        let self_for_task = Arc::downgrade(self);
         tokio::spawn(async move {
             while let Some(()) = rx.recv().await {
-                if let Err(err) = self_for_task.update_from_file().await {
+                // We can upgrade because as long as there is a sender, the webring exists
+                let webring = self_for_task.upgrade().unwrap();
+                if let Err(err) = webring.update_from_file().await {
                     error!("Failed to update webring: {err}");
                 }
                 info!("Webring reloaded");

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -31,6 +31,7 @@ pub enum CheckLevel {
 struct Member {
     name: String,
     website: Arc<Uri>,
+    #[allow(dead_code)] // FIXME: Remove once Discord integration is implemented
     discord_id: String,
     check_level: CheckLevel,
     check_successful: Arc<AtomicBool>,


### PR DESCRIPTION
Uses [the `notify` crate](https://lib.rs/crates/notify) to reload the `Webring` whenever its members list file is changed. Similarly, invalidates the homepage when the `static/index.html` file is changed.