### PR TITLE
Discord integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    environment: Testing
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_PING_USER_ID: ${{ secrets.DISCORD_PING_USER_ID }}
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
@@ -73,7 +77,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        run: cargo test --workspace --all-targets --no-fail-fast --locked
+        run: cargo test --workspace --all-targets --no-fail-fast --locked -- --ignored
 
   # Adding this because we don't want to run the whole build workflow on each
   # push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,10 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
 
-      - name: Run tests
+      - name: Run default tests
+        run: cargo test --workspace --all-targets --no-fail-fast --locked
+
+      - name: Run ignored tests
         run: cargo test --workspace --all-targets --no-fail-fast --locked -- --ignored
 
   # Adding this because we don't want to run the whole build workflow on each

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "reqwest",
  "same-file",
  "serde",
+ "serde_json",
  "surge-ping",
  "tempfile",
  "tera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2024"
 # Enable clippy's pedantic group
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
+# Slice indexing can always panic. Why only warn in match blocks?
+match-on-vec-items = "allow"
 
 [dependencies]
 axum = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,10 @@ log = "0.4.27"
 notify = "8.0.0"
 quick-xml = { version = "0.37.5", features = ["async-tokio"] }
 rand = "0.9.1"
-reqwest = { version = "0.12.15", features = ["stream"] }
+reqwest = { version = "0.12.15", features = ["stream", "json"] }
 same-file = "1.0.6"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 surge-ping = "0.8.2"
 tera = "1.20.0"
 thiserror = "2.0.12"

--- a/src/checking.rs
+++ b/src/checking.rs
@@ -105,11 +105,11 @@ async fn check_impl(
         Ok(response) => response,
         Err(err) => return Some(CheckFailure::Connection(err)),
     };
+    mark_server_as_online().await;
     let successful_response = match response.error_for_status() {
         Ok(r) => r,
         Err(err) => return Some(CheckFailure::ResponseStatus(err.status().unwrap())),
     };
-    mark_server_as_online().await;
 
     if check_level == CheckLevel::ForLinks {
         let stream = successful_response.bytes_stream();

--- a/src/checking.rs
+++ b/src/checking.rs
@@ -243,13 +243,13 @@ impl Display for MissingLinks {
         let address = address_string.strip_suffix('/').unwrap_or(&address_string);
         writeln!(f, "Your site is missing the following links:")?;
         if self.home {
-            writeln!(f, "- {address}")?;
+            writeln!(f, "- <{address}>")?;
         }
         if self.next {
-            writeln!(f, "- {address}/next")?;
+            writeln!(f, "- <{address}/next>")?;
         }
         if self.prev {
-            writeln!(f, "- {address}/prev")?;
+            writeln!(f, "- <{address}/prev>")?;
         }
 
         writeln!(

--- a/src/checking.rs
+++ b/src/checking.rs
@@ -38,7 +38,7 @@ async fn is_online() -> bool {
         // Has it been checked within the TTL?
         let ping_info = PING_INFO.read().await;
         let now = Utc::now().timestamp_millis();
-        if now < ping_info.0 + 1000 {
+        if now < ping_info.0 + ONLINE_CHECK_TTL_MS {
             return ping_info.1;
         }
     }

--- a/src/checking.rs
+++ b/src/checking.rs
@@ -227,7 +227,8 @@ impl MissingLinks {
 
 impl Display for MissingLinks {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let address = &self.base_address;
+        let address_string = self.base_address.to_string();
+        let address = address_string.strip_suffix('/').unwrap_or(&address_string);
         writeln!(f, "Your site is missing the following links:")?;
         if self.home {
             writeln!(f, "- {address}")?;

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -5,7 +5,7 @@
 //! [webhook-api-ref]: https://discord.com/developers/docs/resources/webhook#execute-webhook
 //! [^webhook]: Note lakjdf
 
-use std::{str::FromStr, time::Duration};
+use std::{fmt::Display, str::FromStr, time::Duration};
 
 use eyre::{Context, bail};
 use reqwest::{
@@ -44,6 +44,11 @@ impl FromStr for Snowflake {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse().map(Self)
+    }
+}
+impl Display for Snowflake {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -99,7 +104,7 @@ impl DiscordNotifier {
                 {
                     "content": message,
                     "allowed_mentions": match ping {
-                        Some(id) => json!({ "users": [id] }),
+                        Some(id) => json!({ "users": [id.to_string()] }),
                         None => json!({}),
                     },
                     "flags": SUPPRESS_EMBEDS,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,9 +1,8 @@
 //! Send messages to members over Discord
 //!
-//! Uses [Discord's webhook feature][webhook-api-ref].[^webhook]
+//! Uses [Discord's webhook feature][webhook-api-ref].
 //!
 //! [webhook-api-ref]: https://discord.com/developers/docs/resources/webhook#execute-webhook
-//! [^webhook]: Note lakjdf
 
 use std::{fmt::Display, str::FromStr, time::Duration};
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -114,7 +114,7 @@ impl DiscordNotifier {
             .send()
             .await
             .map_err(reqwest::Error::without_url)
-            .wrap_err("Failed to send notification to Discord")
+            .wrap_err("Failed to execute Discord webhook")
     }
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,0 +1,158 @@
+//! Send messages to members over Discord
+//!
+//! Uses [Discord's webhook feature][webhook-api-ref].[^webhook]
+//!
+//! [webhook-api-ref]: https://discord.com/developers/docs/resources/webhook#execute-webhook
+//! [^webhook]: Note lakjdf
+
+use std::{str::FromStr, time::Duration};
+
+use eyre::{Context, bail};
+use reqwest::{
+    Client, Response, StatusCode, Url,
+    header::{self, HeaderValue},
+};
+use serde::Serialize;
+use serde_json::json;
+
+/// A user agent representing our program. [Required by Discord][api-doc-ua].
+///
+/// [api-doc-ua]: https://discord.com/developers/docs/reference#user-agent
+const USER_AGENT: &str = concat!(
+    "Purdue Hackers Webring (",
+    env!("CARGO_PKG_REPOSITORY"),
+    ", ",
+    env!("CARGO_PKG_VERSION"),
+    ")"
+);
+
+/// Represents a snowflake, the type used to encode identifiers in Discord APIs.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct Snowflake(u64);
+impl From<u64> for Snowflake {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+impl From<Snowflake> for u64 {
+    fn from(value: Snowflake) -> Self {
+        value.0
+    }
+}
+impl FromStr for Snowflake {
+    type Err = <u64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DiscordNotifier {
+    webhook_url: reqwest::Url,
+    client: Client,
+}
+
+impl DiscordNotifier {
+    /// Create a new notifier that sends notifications using the given
+    /// [webhook](https://discord.com/developers/docs/resources/webhook#execute-webhook) URL.
+    pub fn new(webhook_url: &Url) -> Self {
+        Self {
+            webhook_url: webhook_url.to_owned(),
+            client: Client::new(),
+        }
+    }
+
+    /// Send a message in the channel this notifier is registered to.
+    pub async fn send_message(&self, ping: Option<Snowflake>, message: &str) -> eyre::Result<()> {
+        loop {
+            let response = self.send_single_message(ping, message).await?;
+            // If we get rate limited, try again.
+            // See https://discord.com/developers/docs/topics/rate-limits.
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                match response.headers().get(header::RETRY_AFTER) {
+                    Some(value) => {
+                        sleep_from_retry_after(value).await?;
+                        continue;
+                    }
+                    None => bail!("Got rate-limited but response contains no Retry-After header"),
+                }
+            }
+            response
+                .error_for_status()
+                .wrap_err("Discord webhook returned error")?;
+            break;
+        }
+        Ok(())
+    }
+
+    async fn send_single_message(
+        &self,
+        ping: Option<Snowflake>,
+        message: &str,
+    ) -> eyre::Result<Response> {
+        const SUPPRESS_EMBEDS: u16 = 1 << 2;
+        self.client
+            .post(self.webhook_url.clone())
+            .header(header::USER_AGENT, USER_AGENT)
+            .json(&json!(
+                {
+                    "content": message,
+                    "allowed_mentions": match ping {
+                        Some(id) => json!({ "users": [id] }),
+                        None => json!({}),
+                    },
+                    "flags": SUPPRESS_EMBEDS,
+                }
+            ))
+            .query(&[("wait", "true")])
+            .send()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .wrap_err("Failed to send notification to Discord")
+    }
+}
+
+/// Sleep for the number of seconds specified in the `Retry-After` HTTP header of a response.
+///
+/// Returns an `Err` if the `Retry-After` value cannot be parsed.
+async fn sleep_from_retry_after(header_val: &HeaderValue) -> eyre::Result<()> {
+    let val_str = header_val
+        .to_str()
+        .wrap_err("Retry-After header is invalid")?;
+    let seconds = val_str
+        .parse::<u64>()
+        .wrap_err("Retry-After header cannot be parsed into a u64")?;
+    tokio::time::sleep(Duration::from_secs(seconds)).await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Url;
+
+    use super::DiscordNotifier;
+
+    /// Tests sending a message in Discord.
+    ///
+    /// Requires the following environment variables:
+    /// - `DISCORD_WEBHOOK_URL`: The Discord webhook URL to send test messages to.
+    /// - `DISCORD_PING_USER_ID`: The ID of the user to ping.
+    #[tokio::test]
+    #[ignore = "requires secret Discord webhook environment"]
+    async fn send_notification() {
+        let url = std::env::var("DISCORD_WEBHOOK_URL").unwrap();
+        let user_id = std::env::var("DISCORD_PING_USER_ID").unwrap();
+        let notifier = DiscordNotifier::new(&Url::parse(&url).unwrap());
+        // Send a message with no ping
+        notifier.send_message(None, "this is a test").await.unwrap();
+        // Send a message with a ping
+        notifier
+            .send_message(
+                Some(user_id.parse().unwrap()),
+                &format!("this is a test to ping <@{user_id}>"),
+            )
+            .await
+            .unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,8 +172,10 @@ async fn main() -> ExitCode {
         const SITE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 5);
         let webring_for_task = Arc::clone(&webring);
         tokio::spawn(async move {
-            webring_for_task.check_members().await;
-            tokio::time::sleep(SITE_CHECK_INTERVAL).await;
+            loop {
+                webring_for_task.check_members().await;
+                tokio::time::sleep(SITE_CHECK_INTERVAL).await;
+            }
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,9 +172,7 @@ async fn main() -> ExitCode {
         const SITE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 5);
         let webring_for_task = Arc::clone(&webring);
         tokio::spawn(async move {
-            if let Err(err) = webring_for_task.check_members().await {
-                log::error!("Failed to check members: {err}");
-            }
+            webring_for_task.check_members().await;
             tokio::time::sleep(SITE_CHECK_INTERVAL).await;
         });
     }

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -51,7 +51,6 @@ impl FromStr for CheckLevel {
 struct Member {
     name: String,
     website: Arc<Uri>,
-    #[allow(dead_code)] // FIXME: Remove once Discord integration is implemented
     discord_id: Option<Snowflake>,
     check_level: CheckLevel,
     check_successful: Arc<AtomicBool>,

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -23,11 +23,11 @@ use crate::{
     homepage::{Homepage, MemberForHomepage},
 };
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CheckLevel {
-    ForLinks,
-    JustOnline,
     None,
+    JustOnline,
+    ForLinks,
 }
 
 impl FromStr for CheckLevel {

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -73,7 +73,7 @@ impl Member {
             if let Some(failure) = &check_result {
                 successful.store(false, Ordering::Relaxed);
                 if let (Some(notifier), Some(user_id)) = (notifier, discord_id_for_block) {
-                    let message = failure.to_message();
+                    let message = format!("<@{}> {}", user_id, failure.to_message());
                     tokio::spawn(async move {
                         notifier
                             .send_message(Some(user_id), &message)

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -75,10 +75,9 @@ impl Member {
                 if let (Some(notifier), Some(user_id)) = (notifier, discord_id_for_block) {
                     let message = format!("<@{}> {}", user_id, failure.to_message());
                     tokio::spawn(async move {
-                        notifier
-                            .send_message(Some(user_id), &message)
-                            .await
-                            .unwrap();
+                        if let Err(err) = notifier.send_message(Some(user_id), &message).await {
+                            log::error!("Error sending Discord notification: {err}");
+                        }
                     });
                 }
             } else {

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -35,12 +35,12 @@ impl FromStr for CheckLevel {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().as_str() {
-            "for links" => CheckLevel::ForLinks,
-            "just online" => CheckLevel::JustOnline,
+            "links" => CheckLevel::ForLinks,
+            "online" => CheckLevel::JustOnline,
             "none" => CheckLevel::None,
             _ => {
                 bail!(
-                    "Expected the check level to be one of {{\"for links\", \"just online\", \"none\"}}. Got \"{s}\""
+                    "Expected the check level to be one of {{\"links\", \"online\", \"none\"}}. Got \"{s}\""
                 );
             }
         })


### PR DESCRIPTION
Sends Discord notifications when site checks fail.

Closes #7 

# Nitpicks
- The `discord::tests::send_notifications` unit test is really an integration test disguised as a unit test. But since we don't have real integration testing set up (yet), it's probably best to just leave it that way.
- The messages aren't formatted as nicely as the current webring's messages.

# To do
- [x] Rebase on `rust` now that #18 is merged.
- [x] Test that a failing site does actually trigger a notification.
- [x] Fix unfinished doc comments.