### PR TITLE
Use TOML configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1526,6 +1527,7 @@ dependencies = [
  "futures",
  "html-escape",
  "http-body-util",
+ "indexmap",
  "indoc",
  "log",
  "lol_html",
@@ -2401,6 +2403,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,6 +1221,9 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "lol_html"
@@ -1534,6 +1537,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
+ "toml",
  "tower",
  "tower-http",
 ]
@@ -2066,6 +2070,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2387,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -2948,6 +3002,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1526,7 @@ dependencies = [
  "futures",
  "html-escape",
  "http-body-util",
+ "indoc",
  "log",
  "lol_html",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ eyre = "0.6.12"
 ftail = "0.3.0"
 futures = "0.3.31"
 html-escape = "0.2.13"
+indexmap = { version = "2.9.0", features = ["serde"] }
 log = { version = "0.4.27", features = ["serde"] }
 lol_html = "2.4.0"
 notify = "8.0.0"
@@ -40,7 +41,7 @@ tera = "1.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.15", features = ["io"] }
-toml = "0.8.22"
+toml = { version = "0.8.22", features = ["preserve_order"] }
 tower-http = { version = "0.6.4", features = ["cors", "fs", "catch-panic"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tower-http = { version = "0.6.4", features = ["cors", "fs", "catch-panic"] }
 
 [dev-dependencies]
 http-body-util = "0.1.3"
+indoc = "2.0.6"
 pretty_assertions = "1.4.1"
 tempfile = "3.20.0"
 tower = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "ph-webring"
 version = "0.0.0"
 description = "Purdue Hackers' webring server"
 repository = "https://github.com/purduehackers/webring"
+homepage = "https://ring.purduehackers.com"
 authors = [
     "Kian Kasad <kian@kasad.com>",
     "Henry Rovnyak <h.rovnyak@proton.me>",
@@ -24,7 +25,7 @@ eyre = "0.6.12"
 ftail = "0.3.0"
 futures = "0.3.31"
 html-escape = "0.2.13"
-log = "0.4.27"
+log = { version = "0.4.27", features = ["serde"] }
 lol_html = "2.4.0"
 notify = "8.0.0"
 papaya = { version = "0.2.1", features = ["serde"] }
@@ -39,6 +40,7 @@ tera = "1.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.15", features = ["io"] }
+toml = "0.8.22"
 tower-http = { version = "0.6.4", features = ["cors", "fs", "catch-panic"] }
 
 [dev-dependencies]

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -1,0 +1,236 @@
+# Configuring the webring
+
+The webring is configured via a file [in TOML format][toml].
+The rest of this document describes the format of the file and the settings it
+can contain.
+For the exact implementation, see the `Config` struct in `src/config.rs`.
+
+[toml]: https://toml.io/en/
+
+## TOML introduction
+
+In general, TOML files are made up of tables which contain key-value pairs.
+A key can have a table as its value, meaning tables can contain nested tables.
+Tables can be written in several ways. All of the following are equivalent in TOML:
+- ```toml
+  [my-table]
+  key = "value"
+  ```
+- ```toml
+  my-table = { key = "value" }
+  ```
+- ```toml
+  my-table.key = "value"
+  ```
+This flexibility allows you to specify options using whichever form you like.
+
+To provide organization, the webring's settings are split into several tables.
+The settings are listed below, grouped into the tables they belong to. Tables
+for which no settings are specified can be omitted.
+
+Some settings are required, and some are not. Some have defaults, and some do
+not. If a setting is not specified in the configuration file, the following
+happens:
+| Required | Has default | Result                              |
+| ---      | ---         | ---                                 |
+| Yes      | No          | Error; webring will not start       |
+| Yes      | Yes         | Default value will be used          |
+| No       | No          | Setting is empty, i.e. has no value |
+| No       | Yes         | Default value will be used          |
+
+## `webring` table
+
+This table contains settings pertaining to the webring server.
+
+| Key          | Required | Type          | Default                          |
+| ---          | ---      | ---           | ---                              |
+| `base-url`   | no       | string (URL)  | `https://ring.purduehackers.com` |
+| `static-dir` | yes      | string (path) | none                             |
+
+Example:
+```toml
+[webring]
+base-url = "https://ring.purduehackers.com"
+static-dir = "static"
+```
+
+### `base-url`
+
+Defines the URL of the webring itself. This is used mainly when checking
+members' sites to ensure they contain the correct links. The webring must know
+its own URL in order to know what the links to it should look like.
+
+This URL must not be relative, i.e. it must have a valid authority (a.k.a.
+"host" or "domain"). For example, `file:///ring`, while a valid URL, will be
+rejected.
+
+### `static-dir`
+
+The directory from which static content will be served. Files in this directory
+will be served with the path prefix `/static`. E.g. if the value of `static-dir`
+is `/www/ring`, and the webring receives a request for `/static/error.html`, it
+will serve `/www/ring/error.html`.
+
+This directory also has a special purpose: the `index.html` file is a template
+used to render the homepage, populated with the values of the ring's members.
+See [`Homepage.md`](./Homepage.md).
+
+Note that this path is relative to the working directory in which the webring is
+run, not necessarily relative to the location of the configuration file.
+However, it is recommended to run the webring in the directory containing the
+configuration file, so that there is no confusion about relative paths.
+
+## `network` table
+
+Settings pertaining to how the webring communicates over the network.
+
+| Key           | Required | Type               | Default |
+| ---           | ---      | ---                | ---     |
+| `listen-addr` | yes      | string (`ip:port`) | none    |
+
+### `listen-addr`
+
+Specifies the address on which the webring will listen.
+
+The value must be a string which can be parsed as a [`SocketAddr`][socketaddr],
+e.g. an IPv4 or IPv6 address followed by a colon and a port number. For more
+details on the format, see [here for IPv4][v4] and [here for IPv6][v6].
+
+[socketaddr]: https://doc.rust-lang.org/std/net/enum.SocketAddr.html
+[v4]: https://doc.rust-lang.org/std/net/struct.SocketAddrV4.html#textual-representation
+[v6]: https://doc.rust-lang.org/std/net/struct.SocketAddrV6.html#textual-representation
+
+You probably want to use the address `0.0.0.0` or `[::]`, meaning listen on all
+available IPv4 or IPv6 interfaces, respectively.
+
+## `logging` table
+
+Controls the webring's logging behavior.
+
+| Key                         | Required | Type                                                             | Default                                             |
+| ---                         | ---      | ---                                                              | ---                                                 |
+| `verbosity` (alias `level`) | no       | string (one of `off`, `trace`, `debug`, `info`, `warn`, `error`) | `info` for release builds; `debug` for debug builds |
+| `log-file`                  | no       | string (path)                                                    | none                                                |
+
+Example:
+```toml
+[logging]
+level = "info"
+```
+
+### `verbosity` (alias `level`)
+
+Sets the minimum severity to log. Messages with this severity or higher will be
+logged, and those with lower severity will be suppressed.
+
+For example, at level `info`, messages at `info`, `warn`, and `error` will be
+printed, and messages at `trace` and `debug` will not.
+
+The value `off` means no messages will be printed; logging is disabled.
+
+### `log-file`
+
+Specifies a path to a file to write logs to in addition to the standard error
+stream. New log lines will be appended to the file; the webring will never
+truncate the file. The file will be created if it does not exist.
+
+## `discord` table
+
+Controls the Discord integration.
+
+| Key           | Required | Type         | Default |
+| ---           | ---      | ---          | ---     |
+| `webhook-url` | no       | string (URL) | none    |
+
+### `webhook-url`
+
+Sets the URL of the Discord webhook, which will be executed to send messages.
+This must be the full URL of an [Execute Webhook API endpoint][webhook].
+
+If set, members whose sites fail validation (and whose `discord-id` is set) will
+be sent a message on Discord explaining the problem. The message is sent to
+whichever server and channel the webhook is created for.
+
+[webhook]: https://discord.com/developers/docs/resources/webhook#execute-webhook
+
+## `members` table
+
+This table is a little different; instead of unique settings, it contains the
+list of the webring's members. Each key in this table is the name of a member,
+and the value is a table configuring the member's site. While all settings
+discussed so far apply to the webring as a whole, each member's table is unique
+to that member; the settings within do not apply to other members.
+
+Member settings:
+| Key           | Required | Type                                                        | Default |
+| ---           | ---      | ---                                                         | ---     |
+| `url`         | yes      | string (URL)                                                | none    |
+| `discord-id`  | no       | integer                                                     | none    |
+| `check-level` | no       | string (one of `none`/`off`, `online`/`up`, `links`/`full`) | `full`  |
+
+Examples (all are equivalent):
+
+- ```toml
+  [members.kian]
+  url = "https://kasad.com"
+  discord-id = 123
+
+  [members.henry]
+  url = "https://hrovnyak.gitlab.io"
+  check-level = "online"
+  ```
+
+- ```toml
+  [members]
+  kian = { url = "https://kasad.com", discord-id = 123 }
+  henry = { url = "https://hrovnyak.gitlab.io", check-level = "online" }
+  ```
+
+- ```toml
+  members.kian = { url = "https://kasad.com", discord-id = 123 }
+  members.henry = { url = "https://hrovnyak.gitlab.io", check-level = "online" }
+  ```
+
+- ```toml
+  members.kian.url = "https://kasad.com"
+  members.kian.discord-id = 123
+  members.henry.url = "https://hrovnyak.gitlab.io"
+  members.henry.check-level = "online"
+  ```
+
+### `url`
+
+The URL of the member's site.
+
+### `discord-id`
+
+The member's Discord user ID. Note that this is *not* their username, but rather
+is a number. See [this article][discord-user-id] for how to find someone's user
+ID.
+
+If unset, this member will not be notified on Discord when their site fails checks.
+
+[discord-user-id]: https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID
+
+See [the `discord` table](#discord-table) for more on the Discord integration.
+
+### `check-level`
+
+The level of check to perform on this member's site. Checks are performed on
+every site before users are sent there. E.g. if the user requests the next site
+in the ring coming from **A**, and site **B** is not online, **B** will be
+silently skipped and the user will be sent to the next passing site, e.g. **C**.
+
+The options are:
+- `off` or `none`: No checks are performed. The site is considered to always be
+  passing.
+- `up` or `online`: The site is considered to pass if it responds to HTTP
+  requests with a successful (200-299) response.
+- `full` or `links`: The site must pass the previous check, and must also
+  respond with an HTML body containing links (`<a>` elements) with the following
+  destinations as their destination (`href` attribute):
+  - `<RING_BASE_URL>`
+  - `<RING_BASE_URL>/prev` or `<RING_BASE_URL>/previous` (with optional `?host=` parameter)
+  - `<RING_BASE_URL>/next` (with optional `?host=` parameter)
+
+  If any of these links is missing, the site fails the check.

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -38,7 +38,9 @@ happens:
 | No       | No          | Setting is empty, i.e. has no value |
 | No       | Yes         | Default value will be used          |
 
-## `webring` table
+## Available settings
+
+### `webring` table
 
 This table contains settings pertaining to the webring server.
 
@@ -54,7 +56,7 @@ base-url = "https://ring.purduehackers.com"
 static-dir = "static"
 ```
 
-### `base-url`
+#### `base-url`
 
 Defines the URL of the webring itself. This is used mainly when checking
 members' sites to ensure they contain the correct links. The webring must know
@@ -64,7 +66,7 @@ This URL must not be relative, i.e. it must have a valid authority (a.k.a.
 "host" or "domain"). For example, `file:///ring`, while a valid URL, will be
 rejected.
 
-### `static-dir`
+#### `static-dir`
 
 The directory from which static content will be served. Files in this directory
 will be served with the path prefix `/static`. E.g. if the value of `static-dir`
@@ -80,7 +82,7 @@ run, not necessarily relative to the location of the configuration file.
 However, it is recommended to run the webring in the directory containing the
 configuration file, so that there is no confusion about relative paths.
 
-## `network` table
+### `network` table
 
 Settings pertaining to how the webring communicates over the network.
 
@@ -88,7 +90,7 @@ Settings pertaining to how the webring communicates over the network.
 | ---           | ---      | ---                | ---     |
 | `listen-addr` | yes      | string (`ip:port`) | none    |
 
-### `listen-addr`
+#### `listen-addr`
 
 Specifies the address on which the webring will listen.
 
@@ -103,7 +105,7 @@ details on the format, see [here for IPv4][v4] and [here for IPv6][v6].
 You probably want to use the address `0.0.0.0` or `[::]`, meaning listen on all
 available IPv4 or IPv6 interfaces, respectively.
 
-## `logging` table
+### `logging` table
 
 Controls the webring's logging behavior.
 
@@ -118,7 +120,7 @@ Example:
 level = "info"
 ```
 
-### `verbosity` (alias `level`)
+#### `verbosity` (alias `level`)
 
 Sets the minimum severity to log. Messages with this severity or higher will be
 logged, and those with lower severity will be suppressed.
@@ -128,13 +130,13 @@ printed, and messages at `trace` and `debug` will not.
 
 The value `off` means no messages will be printed; logging is disabled.
 
-### `log-file`
+#### `log-file`
 
 Specifies a path to a file to write logs to in addition to the standard error
 stream. New log lines will be appended to the file; the webring will never
 truncate the file. The file will be created if it does not exist.
 
-## `discord` table
+### `discord` table
 
 Controls the Discord integration.
 
@@ -142,7 +144,7 @@ Controls the Discord integration.
 | ---           | ---      | ---          | ---     |
 | `webhook-url` | no       | string (URL) | none    |
 
-### `webhook-url`
+#### `webhook-url`
 
 Sets the URL of the Discord webhook, which will be executed to send messages.
 This must be the full URL of an [Execute Webhook API endpoint][webhook].
@@ -153,7 +155,7 @@ whichever server and channel the webhook is created for.
 
 [webhook]: https://discord.com/developers/docs/resources/webhook#execute-webhook
 
-## `members` table
+### `members` table
 
 This table is a little different; instead of unique settings, it contains the
 list of the webring's members. Each key in this table is the name of a member,
@@ -198,11 +200,11 @@ Examples (all are equivalent):
   members.henry.check-level = "online"
   ```
 
-### `url`
+#### `url`
 
 The URL of the member's site.
 
-### `discord-id`
+#### `discord-id`
 
 The member's Discord user ID. Note that this is *not* their username, but rather
 is a number. See [this article][discord-user-id] for how to find someone's user
@@ -214,12 +216,12 @@ If unset, this member will not be notified on Discord when their site fails chec
 
 See [the `discord` table](#discord-table) for more on the Discord integration.
 
-### `check-level`
+#### `check-level`
 
 The level of check to perform on this member's site. Checks are performed on
 every site before users are sent there. E.g. if the user requests the next site
 in the ring coming from **A**, and site **B** is not online, **B** will be
-silently skipped and the user will be sent to the next passing site, e.g. **C**.
+silently skipped, and the user will be sent to the next passing site, e.g. **C**.
 
 The options are:
 - `off` or `none`: No checks are performed. The site is considered to always be
@@ -233,4 +235,16 @@ The options are:
   - `<RING_BASE_URL>/prev` or `<RING_BASE_URL>/previous` (with optional `?host=` parameter)
   - `<RING_BASE_URL>/next` (with optional `?host=` parameter)
 
-  If any of these links is missing, the site fails the check.
+  If any of these links is missing, the site fails the check. Additionally,
+  elements of any kind with a `data-phwebring` attribute containing the value
+  `home`, `prev`/`previous`, or `next` will be accepted instead of a link
+  element.
+
+## Live reloading
+
+If the configuration file is changed while the webring is running, this change
+will be detected, and the webring will attempt to re-load the member list.
+**Only the `members` table is re-loaded; other changes will not be applied.**
+
+If the updated configuration file is invalid, an error will be logged and the
+update will be ignored, leaving the webring running the old configuration.

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -244,7 +244,7 @@ The options are:
 
 If the configuration file is changed while the webring is running, this change
 will be detected, and the webring will attempt to re-load the member list.
-**Only the `members` table is re-loaded; other changes will not be applied.**
+Only the `members` table is re-loaded; other changes will not be applied.
 
 If the updated configuration file is invalid, an error will be logged and the
 update will be ignored, leaving the webring running the old configuration.

--- a/members.txt
+++ b/members.txt
@@ -1,4 +1,0 @@
-henry — hrovnyak.gitlab.io — 123 — None
-kian — kasad.com — 456 — NonE
-cynthia — https://clementine.viridian.page — 789 — nONE
-??? — ws://refuse-the-r.ing — - — none

--- a/members.txt
+++ b/members.txt
@@ -1,0 +1,4 @@
+henry — hrovnyak.gitlab.io — 123 — None
+kian — kasad.com — 456 — NonE
+cynthia — https://clementine.viridian.page — 789 — nONE
+??? — ws://refuse-the-r.ing — - — none

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,7 +62,7 @@ pub struct NetworkTable {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LoggingTable {
     /// Log verbosity
-    #[serde(with = "LevelFilterWrapper")]
+    #[serde(alias = "level", with = "LevelFilterWrapper")]
     pub verbosity: LevelFilter,
 
     /// File to print logs to in addition to the console

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,143 @@
+//! Configuration file handling
+
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
+
+use axum::http::Uri;
+use eyre::Context;
+use log::LevelFilter;
+use reqwest::Url;
+use sarlacc::Intern;
+use serde::{Deserialize, Deserializer, de};
+
+/// Webring configuration object
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Config {
+    pub webring: WebringTable,
+    pub network: NetworkTable,
+    #[serde(default = "default_logging_table")]
+    pub logging: LoggingTable,
+    pub discord: Option<DiscordTable>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct WebringTable {
+    /// Directory from which to serve static content
+    pub static_dir: PathBuf,
+
+    /// File to read member database from
+    pub members_file: PathBuf,
+
+    /// Base URL of the webring, e.g. `https://ring.purduehackers.com`
+    #[serde(
+        default = "default_address",
+        deserialize_with = "deserialize_interned_uri"
+    )]
+    pub base_url: Intern<Uri>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct NetworkTable {
+    /// Address/port to listen on
+    pub listen_addr: SocketAddr,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LoggingTable {
+    /// Log verbosity
+    #[serde(with = "LevelFilterWrapper")]
+    pub verbosity: LevelFilter,
+
+    /// File to print logs to in addition to the console
+    pub log_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DiscordTable {
+    /// Discord webhook URL
+    #[serde(deserialize_with = "deserialize_url")]
+    pub webhook_url: Url,
+}
+
+// This type exists so serde can figure out what variants are available for the verbosity option.
+// If we use LevelFilter directly, it uses the Display and FromStr implementations, which means
+// there isn't a list of possible variants for clap to use.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "lowercase", remote = "LevelFilter")]
+enum LevelFilterWrapper {
+    Off,
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<LevelFilterWrapper> for LevelFilter {
+    fn from(val: LevelFilterWrapper) -> Self {
+        match val {
+            LevelFilterWrapper::Off => LevelFilter::Off,
+            LevelFilterWrapper::Trace => LevelFilter::Trace,
+            LevelFilterWrapper::Debug => LevelFilter::Debug,
+            LevelFilterWrapper::Info => LevelFilter::Info,
+            LevelFilterWrapper::Warn => LevelFilter::Warn,
+            LevelFilterWrapper::Error => LevelFilter::Error,
+        }
+    }
+}
+
+/// Get default webring base address.
+fn default_address() -> Intern<Uri> {
+    Intern::new(Uri::from_static(env!("CARGO_PKG_HOMEPAGE")))
+}
+
+/// Get default log level.
+fn default_logging_table() -> LoggingTable {
+    let level = if cfg!(debug_assertions) {
+        LevelFilter::Debug
+    } else {
+        LevelFilter::Info
+    };
+    LoggingTable {
+        verbosity: level,
+        log_file: None,
+    }
+}
+
+// Deserialize an `Intern<Uri>` from a string value
+fn deserialize_interned_uri<'de, D>(deserializer: D) -> Result<Intern<Uri>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let uri = Uri::try_from(s).map_err(de::Error::custom)?;
+    if uri.authority().is_none() {
+        return Err(de::Error::custom(
+            "URL does not have a host/authority component",
+        ));
+    }
+    Ok(Intern::new(uri))
+}
+
+// Deserialize an `Option<Url>` from a string value
+fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Url::parse(<&str>::deserialize(deserializer)?).map_err(de::Error::custom)
+}
+
+impl Config {
+    /// Load configuration from the given TOML file.
+    pub async fn parse_from_file(path: &Path) -> eyre::Result<Self> {
+        let file_contents = tokio::fs::read_to_string(path).await?;
+        toml::from_str(&file_contents).wrap_err("Failed to load configuration file")
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,15 @@ impl Config {
         let file_contents = tokio::fs::read_to_string(path).await?;
         Ok(toml::from_str(&file_contents)?)
     }
+
+    /// Returns `true` if any settings other than members have changed between the old and new
+    /// configurations.
+    pub fn diff_settings(old: &Config, new: &Config) -> bool {
+        old.webring != new.webring
+            || old.network != new.network
+            || old.logging != new.logging
+            || old.discord != new.discord
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ use crate::{discord::Snowflake, webring::CheckLevel};
 pub struct Config {
     pub webring: WebringTable,
     pub network: NetworkTable,
-    #[serde(default = "default_logging_table")]
+    #[serde(default)]
     pub logging: LoggingTable,
     pub discord: Option<DiscordTable>,
 
@@ -67,6 +67,19 @@ pub struct LoggingTable {
 
     /// File to print logs to in addition to the console
     pub log_file: Option<PathBuf>,
+}
+
+impl Default for LoggingTable {
+    fn default() -> Self {
+        Self {
+            verbosity: if cfg!(debug_assertions) {
+                LevelFilter::Debug
+            } else {
+                LevelFilter::Info
+            },
+            log_file: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -132,19 +145,6 @@ impl From<LevelFilterWrapper> for LevelFilter {
 /// Get default webring base address.
 fn default_address() -> Intern<Uri> {
     Intern::new(Uri::from_static(env!("CARGO_PKG_HOMEPAGE")))
-}
-
-/// Get default log level.
-fn default_logging_table() -> LoggingTable {
-    let level = if cfg!(debug_assertions) {
-        LevelFilter::Debug
-    } else {
-        LevelFilter::Info
-    };
-    LoggingTable {
-        verbosity: level,
-        log_file: None,
-    }
 }
 
 // Deserialize an `Intern<Uri>` from a string value

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -11,7 +11,7 @@ use reqwest::{
     Client, Response, StatusCode, Url,
     header::{self, HeaderValue},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 /// A user agent representing our program. [Required by Discord][api-doc-ua].
@@ -26,7 +26,7 @@ const USER_AGENT: &str = concat!(
 );
 
 /// Represents a snowflake, the type used to encode identifiers in Discord APIs.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Snowflake(u64);
 impl From<u64> for Snowflake {
     fn from(value: u64) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,5 @@
 use std::{
-    convert::AsRef,
-    env::args_os,
     io::{IsTerminal, stderr},
-    iter::once,
     net::SocketAddr,
     path::PathBuf,
     process::ExitCode,
@@ -10,140 +7,52 @@ use std::{
     time::Duration,
 };
 
-use axum::http::{Uri, uri::Scheme};
-use clap::{Parser, ValueEnum};
+use clap::Parser;
+use config::Config;
 use discord::DiscordNotifier;
 use ftail::Ftail;
-use log::LevelFilter;
-use reqwest::Url;
 use routes::create_router;
-use sarlacc::Intern;
 use webring::Webring;
 
 mod checking;
+mod config;
 mod discord;
 mod homepage;
 mod routes;
 mod stats;
 mod webring;
 
-/// Default log level.
-const DEFAULT_LOG_LEVEL: LevelFilterWrapper = if cfg!(debug_assertions) {
-    LevelFilterWrapper::Debug
-} else {
-    LevelFilterWrapper::Info
-};
-
 #[derive(clap::Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 struct CliOptions {
-    /// Address/port to listen on
-    #[arg(short, long = "listen-on", default_value = "0.0.0.0:3000")]
-    listen_addr: SocketAddr,
-
-    /// Log verbosity
-    #[arg(short, long, alias = "log-level", value_enum, default_value_t = DEFAULT_LOG_LEVEL)]
-    verbosity: LevelFilterWrapper,
-
-    /// File to print logs to in addition to the console
-    #[arg(short = 'o', long)]
-    log_file: Option<PathBuf>,
-
-    /// Directory from which to serve static content
-    #[arg(short = 'd', long, default_value = "static")]
-    static_dir: PathBuf,
-
-    /// File to read more arguments from
-    #[arg(short = 'f', long)]
-    arg_file: Option<PathBuf>,
-
-    /// File to read member database from
-    #[arg(short = 'm', long)]
-    members_file: PathBuf,
-
-    #[arg(short = 'a', long, default_value = "https://ring.purduehackers.com", value_parser = parse_uri)]
-    address: Intern<Uri>,
-
-    /// Discord webhook URL
-    #[arg(long)]
-    discord_webhook_url: Option<Url>,
-}
-
-fn parse_uri(str: &str) -> eyre::Result<Intern<Uri>> {
-    let uri = str.parse::<Uri>()?;
-
-    if !uri.path().trim_matches('/').is_empty() {
-        return Err(eyre::eyre!(
-            "Expected the address URI to not have a path component."
-        ));
-    }
-
-    if ![None, Some(&Scheme::HTTPS), Some(&Scheme::HTTP)].contains(&uri.scheme()) {
-        return Err(eyre::eyre!(
-            "Expected the scheme to be either `HTTP` or `HTTPS`"
-        ));
-    }
-
-    if uri.authority().is_none() {
-        return Err(eyre::eyre!(
-            "Expected the address URI to have an authority component (to not be a relative path)."
-        ));
-    }
-
-    Ok(Intern::new(uri))
-}
-
-// This type exists so clap can figure out what variants are available for the verbosity option.
-// If we use LevelFilter directly, it uses the Display and FromStr implementations, which means
-// there isn't a list of possible variants for clap to use.
-#[derive(ValueEnum, Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum LevelFilterWrapper {
-    Off,
-    Trace,
-    Debug,
-    Info,
-    Warn,
-    Error,
-}
-
-impl From<LevelFilterWrapper> for LevelFilter {
-    fn from(val: LevelFilterWrapper) -> Self {
-        match val {
-            LevelFilterWrapper::Off => LevelFilter::Off,
-            LevelFilterWrapper::Trace => LevelFilter::Trace,
-            LevelFilterWrapper::Debug => LevelFilter::Debug,
-            LevelFilterWrapper::Info => LevelFilter::Info,
-            LevelFilterWrapper::Warn => LevelFilter::Warn,
-            LevelFilterWrapper::Error => LevelFilter::Error,
-        }
-    }
+    /// Path of configuration file to read
+    #[arg(short = 'f', default_value = "webring.toml")]
+    config_file: PathBuf,
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
     // Parse CLI options
-    let mut cli = CliOptions::parse();
-    if let Some(path) = &cli.arg_file {
-        match std::fs::read_to_string(path) {
-            Ok(contents) => {
-                let argv0 = args_os().next().unwrap();
-                cli.update_from(
-                    once(argv0.as_os_str()).chain(contents.split_whitespace().map(AsRef::as_ref)),
-                );
-            }
-            Err(err) => eprintln!("Error: failed to read argument file: {err}"),
+    let cli = CliOptions::parse();
+
+    // Load config
+    let cfg = match Config::parse_from_file(&cli.config_file).await {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            eprintln!("Failed to read configuration file: {err}");
+            return ExitCode::FAILURE;
         }
-    }
+    };
 
     // Set up logging
     let mut logger = Ftail::new();
     if stderr().is_terminal() {
-        logger = logger.formatted_console(cli.verbosity.into());
+        logger = logger.formatted_console(cfg.logging.verbosity);
     } else {
-        logger = logger.console(cli.verbosity.into());
+        logger = logger.console(cfg.logging.verbosity);
     }
-    if let Some(path) = &cli.log_file {
-        logger = logger.single_file(path, true, cli.verbosity.into());
+    if let Some(path) = &cfg.logging.log_file {
+        logger = logger.single_file(path, true, cfg.logging.verbosity);
     }
     if let Err(err) = logger.init() {
         eprintln!("Error: failed to initialize logger: {err}");
@@ -151,13 +60,13 @@ async fn main() -> ExitCode {
     }
 
     // Create Discord notifier
-    let maybe_notifier = cli.discord_webhook_url.as_ref().map(DiscordNotifier::new);
+    let maybe_notifier = cfg.discord.map(|dt| DiscordNotifier::new(&dt.webhook_url));
 
     // Create webring data structure
     let webring = match Webring::new(
-        cli.members_file.clone(),
-        cli.static_dir.clone(),
-        cli.address,
+        cfg.webring.members_file.clone(),
+        cfg.webring.static_dir.clone(),
+        cfg.webring.base_url,
         maybe_notifier,
     )
     .await
@@ -187,13 +96,16 @@ async fn main() -> ExitCode {
         log::warn!("Webring will not reload automatically.");
     }
     webring.enable_ip_pruning(chrono::Duration::hours(1));
-    log::info!("Watching {} for changes", cli.members_file.display());
+    log::info!(
+        "Watching {} for changes",
+        cfg.webring.members_file.display()
+    );
 
     // Start server
-    let router = create_router(&cli.static_dir)
+    let router = create_router(&cfg.webring.static_dir)
         .with_state(Arc::clone(&webring))
         .into_make_service_with_connect_info::<SocketAddr>();
-    let bind_addr = &cli.listen_addr;
+    let bind_addr = &cfg.network.listen_addr;
     match tokio::net::TcpListener::bind(bind_addr).await {
         Ok(listener) => {
             match listener.local_addr() {

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -31,8 +31,9 @@ use crate::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CheckLevel {
+    #[serde(alias = "off")]
     None,
-    #[serde(rename = "online")]
+    #[serde(rename = "online", alias = "up")]
     JustOnline,
     #[serde(rename = "links", alias = "full")]
     ForLinks,

--- a/webring.toml
+++ b/webring.toml
@@ -1,0 +1,10 @@
+[webring]
+members-file = "members.txt"
+static-dir = "static"
+base-url = "https://ring.purduehackers.com"
+
+[network]
+listen-addr = "0.0.0.0:3000"
+
+[logging]
+verbosity = "info"

--- a/webring.toml
+++ b/webring.toml
@@ -1,5 +1,4 @@
 [webring]
-members-file = "members.txt"
 static-dir = "static"
 base-url = "https://ring.purduehackers.com"
 
@@ -8,3 +7,9 @@ listen-addr = "0.0.0.0:3000"
 
 [logging]
 verbosity = "info"
+
+[members]
+henry = { url = "hrovnyak.gitlab.io", discord-id = 123, check-level = "none" }
+kian = { url = "kasad.com", discord-id = 456, check-level = "none" }
+cynthia = { url = "https://clementine.viridian.page", discord-id = 789, check-level = "none" }
+"???" = { url = "ws://refuse-the-r.ing", check-level = "none" }


### PR DESCRIPTION
Uses a TOML configuration file instead of command-line arguments for webring configuration.

Closes #19.

# To do

- [x] Load configuration from TOML file
- [x] Write unit tests
- [x] Move member list into configuration file
   - [x] Load members from configuration file
   - [x] Adjust file reloading to work with the changes
- [x] Write documentation


