### PR TITLE
docs: document all items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2024"
 pedantic = { level = "warn", priority = -1 }
 # Slice indexing can always panic. Why only warn in match blocks?
 match-on-vec-items = "allow"
+missing-docs-in-private-items = "warn"
 
 [dependencies]
 axum = { version = "0.8.4", default-features = false, features = [ "http1", "http2", "tokio", "tracing", "query" ] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,10 +18,14 @@ use crate::{discord::Snowflake, webring::CheckLevel};
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
+    /// Ring configuration
     pub webring: WebringTable,
+    /// Network/server configuration
     pub network: NetworkTable,
+    /// Logging configuration
     #[serde(default)]
     pub logging: LoggingTable,
+    /// Discord integration configuration
     pub discord: Option<DiscordTable>,
 
     /// Map from member name to their site details
@@ -46,11 +50,13 @@ pub struct WebringTable {
 }
 
 impl WebringTable {
+    /// Gets the base URL of the webring
     pub fn base_url(&self) -> Intern<Uri> {
         self.base_url
     }
 }
 
+/// Network/server configuration table
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct NetworkTable {
@@ -58,6 +64,7 @@ pub struct NetworkTable {
     pub listen_addr: SocketAddr,
 }
 
+/// Logging configuration table
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LoggingTable {
@@ -82,6 +89,7 @@ impl Default for LoggingTable {
     }
 }
 
+/// Discord integration configuration table
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct DiscordTable {
@@ -103,7 +111,9 @@ pub struct MemberSpec {
         deserialize_with = "deserialize_interned_uri"
     )]
     uri: Intern<Uri>,
+    /// Discord ID of the member, if they opt in to Discord integration
     pub discord_id: Option<Snowflake>,
+    /// Level of checks to perform on the member's site
     #[serde(default)]
     pub check_level: CheckLevel,
 }
@@ -115,17 +125,24 @@ impl MemberSpec {
     }
 }
 
-// This type exists so serde can figure out what variants are available for the verbosity option.
-// If we use LevelFilter directly, it uses the Display and FromStr implementations, which means
-// there isn't a list of possible variants for clap to use.
+/// This type exists so serde can figure out what variants are available for the verbosity option.
+/// If we use [`LevelFilter`] directly, it uses the [`Display`][std::fmt::Display] and
+/// [`FromStr`][std::str::FromStr] implementations, which means there isn't a list of possible
+/// variants for clap to use.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[serde(rename_all = "lowercase", remote = "LevelFilter")]
 enum LevelFilterWrapper {
+    /// No logging
     Off,
+    /// Log everything
     Trace,
+    /// Log debug messages and higher
     Debug,
+    /// Log informational messages and higher
     Info,
+    /// Log warnings and higher
     Warn,
+    /// Log errors only
     Error,
 }
 
@@ -147,7 +164,7 @@ fn default_address() -> Intern<Uri> {
     Intern::new(Uri::from_static(env!("CARGO_PKG_HOMEPAGE")))
 }
 
-// Deserialize an `Intern<Uri>` from a string value
+/// Deserialize an `Intern<Uri>` from a string value
 fn deserialize_interned_uri<'de, D>(deserializer: D) -> Result<Intern<Uri>, D::Error>
 where
     D: Deserializer<'de>,
@@ -162,7 +179,7 @@ where
     Ok(Intern::new(uri))
 }
 
-// Deserialize an `Option<Url>` from a string value
+/// Deserialize an `Option<Url>` from a string value
 fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -52,9 +52,12 @@ impl Display for Snowflake {
     }
 }
 
+/// A notifier that sends messages to a Discord channel using a webhook URL.
 #[derive(Clone, Debug)]
 pub struct DiscordNotifier {
+    /// The webhook URL to send messages to.
     webhook_url: reqwest::Url,
+    /// HTTP client used to send requests.
     client: Client,
 }
 
@@ -91,6 +94,14 @@ impl DiscordNotifier {
         Ok(())
     }
 
+    /// Sends a single message to the Discord webhook.
+    ///
+    /// Returns the HTTP [`Response`] from the API.
+    ///
+    /// # Errors
+    ///
+    /// On request error, returns an `Err` with the error details, but with the URL stripped, so it
+    /// can safely be logged or displayed to a user.
     async fn send_single_message(
         &self,
         ping: Option<Snowflake>,
@@ -119,6 +130,8 @@ impl DiscordNotifier {
 }
 
 /// Sleep for the number of seconds specified in the `Retry-After` HTTP header of a response.
+///
+/// # Errors
 ///
 /// Returns an `Err` if the `Retry-After` value cannot be parsed.
 async fn sleep_from_retry_after(header_val: &HeaderValue) -> eyre::Result<()> {

--- a/src/homepage.rs
+++ b/src/homepage.rs
@@ -1,3 +1,5 @@
+//! Handles rendering the webring homepage
+
 use std::path::Path;
 
 use axum::http::{
@@ -8,12 +10,16 @@ use sarlacc::Intern;
 use serde::Serialize;
 use tera::Tera;
 
+/// Represents the rendered webring homepage
 #[derive(Clone, Debug)]
 pub struct Homepage {
+    /// The rendered HTML content of the homepage
     html: String,
 }
 
 impl Homepage {
+    /// Creates a new `Homepage` instance by reading the `index.html` template from the specified
+    /// directory and rendering it with the provided members and base address.
     pub async fn new(
         static_dir: &Path,
         base_address: Intern<Uri>,
@@ -30,15 +36,20 @@ impl Homepage {
         Ok(Self { html })
     }
 
+    /// Returns the rendered HTML content of the homepage.
     pub fn to_html(&self) -> &str {
         &self.html
     }
 }
 
+/// Represents the information about a member to be displayed on the homepage.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct MemberForHomepage {
+    /// Member's name
     pub name: String,
+    /// Member's website URI
     pub website: SerializableUri,
+    /// Whether the member's website check was successful
     pub check_successful: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+//! # Purdue Hackers Webring
+//!
+//! Implements a web server that serves the Purdue Hackers Webring.
+
 use std::{
     io::{IsTerminal, stderr},
     net::SocketAddr,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -308,7 +308,7 @@ enum RouteError {
     MissingOriginURI,
 
     /// The request did not contain a redirect URI, but it was required, e.g. to redirect the user to a member's site.
-    #[error("Request doesn't indicate which site it it is redirecting to.")]
+    #[error("Request doesn't indicate which site it is redirecting to.")]
     MissingRedirectURI,
 
     /// A header in the request could not be converted to a string because it contained invalid UTF-8 data.

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -29,6 +29,7 @@ use tower_http::{
 
 use crate::webring::{TraverseWebringError, Webring};
 
+/// Static HTML template for rendering error responses.
 static ERROR_TEMPLATE: LazyLock<Tera> = LazyLock::new(create_error_template);
 
 /// Creates a [`Router`] with the routes for our application.
@@ -75,6 +76,10 @@ pub fn create_router(static_dir: &Path) -> Router<Arc<Webring>> {
     router.layer(CatchPanicLayer::custom(PanicResponse))
 }
 
+/// Creates a Tera template for rendering error pages.
+///
+/// The template is baked into the binary at compile time using `include_str!`, so it is guaranteed
+/// to be correct and renderable.
 fn create_error_template() -> Tera {
     let html_src = include_str!("templates/error.html");
     let css_src = include_str!("templates/error.css");
@@ -99,6 +104,7 @@ fn redirect_with_content(to: &Uri) -> impl IntoResponse + use<> {
     )
 }
 
+/// Serve the homepage at `/`
 async fn serve_index(
     State(webring): State<Arc<Webring>>,
     headers: HeaderMap,
@@ -253,9 +259,12 @@ fn get_origin_from_request(
     }
 }
 
+/// Represents the part of the request where the origin URI was found.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 enum OriginUriLocation {
+    /// The `Referer` header
     RefererHeader,
+    /// The `?host=` query parameter
     HostQueryParam,
 }
 
@@ -269,32 +278,44 @@ impl Display for OriginUriLocation {
     }
 }
 
+/// Represents errors that can occur while routing requests.
 #[derive(Debug, thiserror::Error)]
 enum RouteError {
+    /// An origing URI was needed to find the next/previous site in the ring, but it was invalid.
     #[error(r#"Origin URI "{uri}" found in {place} is invalid: {reason}."#)]
     InvalidOriginURI {
+        /// The origin URI that was found to be invalid
         uri: String,
+        /// The reason why the URI was invalid
         #[source]
         reason: InvalidUri,
+        /// Where in the request the URI was found
         place: OriginUriLocation,
     },
 
+    /// The URI to which the server should redirect the client was invalid.
     #[error(r#"Redirect URI "{uri}" is invalid: {reason}."#)]
     InvalidRedirectURI {
+        /// The redirect URI that was found to be invalid
         uri: String,
+        /// The reason why the URI was invalid
         #[source]
         reason: InvalidUri,
     },
 
+    /// The request did not contain an origin URI, but it was required, e.g. to find the next/previous site.
     #[error("Request doesn't indicate which site it originates from.")]
     MissingOriginURI,
 
+    /// The request did not contain a redirect URI, but it was required, e.g. to redirect the user to a member's site.
     #[error("Request doesn't indicate which site it it is redirecting to.")]
     MissingRedirectURI,
 
+    /// A header in the request could not be converted to a string because it contained invalid UTF-8 data.
     #[error("{0} contains data which is not valid UTF-8.")]
     HeaderToStr(OriginUriLocation),
 
+    /// An error occurred while traversing the webring.
     #[error("Error traversing webring: {0}")]
     Traversal(
         #[from]
@@ -302,6 +323,7 @@ enum RouteError {
         TraverseWebringError,
     ),
 
+    /// An error occurred while rendering the homepage.
     #[error("Error rendering homepage: {0}.")]
     RenderHomepage(
         #[from]
@@ -309,9 +331,11 @@ enum RouteError {
         eyre::Report,
     ),
 
+    /// No route was found for the given request path.
     #[error("No handler for path {0}")]
     NoRoute(Uri),
 
+    /// A static file was requested, but it does not exist.
     #[error("File {0} does not exist")]
     FileNotFound(String),
 }
@@ -374,6 +398,7 @@ impl IntoResponse for RouteError {
     }
 }
 
+/// A response type that can be used to render an error page when a panic occurs.
 #[derive(Copy, Clone, Debug)]
 struct PanicResponse;
 


### PR DESCRIPTION
Enables the `missing_docs_in_private_items` lint and fixes all warnings that occurred because of it.