### PR TITLE
fix: log check failures using Debug format

### DIFF
--- a/src/checking.rs
+++ b/src/checking.rs
@@ -133,7 +133,7 @@ pub async fn check(
                 }
             }
 
-            info!(site = %website, %failure, "site failed a check");
+            info!(site = %website, ?failure, "site failed a check");
             Ok(Some(failure))
         }
     }


### PR DESCRIPTION
This should allow us to see the source of any `reqwest::Error`s that cause check failures.