### PR TITLE
chore: update Rust toolchain to 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2024"
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 # Slice indexing can always panic. Why only warn in match blocks?
-match-on-vec-items = "allow"
 missing-docs-in-private-items = "warn"
 
 [dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87"
+channel = "1.90"
 components = ["clippy", "rustfmt"]

--- a/src/checking.rs
+++ b/src/checking.rs
@@ -131,15 +131,15 @@ pub async fn check(
             // If the issue is not a connection issue, or if it is a connection issue and the
             // server is online, return it. Otherwise, it's a connection issue on our end, so log
             // and count the check as successful.
-            if let CheckFailure::Connection(connection_error) = &failure {
-                if !is_online().await {
-                    error!(
-                        site = %website,
-                        err = %connection_error,
-                        "Server-side connectivity issue detected: could not reach site"
-                    );
-                    return Err(());
-                }
+            if let CheckFailure::Connection(connection_error) = &failure
+                && !is_online().await
+            {
+                error!(
+                    site = %website,
+                    err = %connection_error,
+                    "Server-side connectivity issue detected: could not reach site"
+                );
+                return Err(());
             }
 
             info!(site = %website, ?failure, "site failed a check");


### PR DESCRIPTION
This is intentionally not the latest version.