### PR TITLE
ci: enable Renovate with auto-merge for Cargo dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,17 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
     "extends": ["config:recommended"],
-    "enabledManagers": ["github-actions", "custom.jsonata"],
+
+    "timezone": "America/Indiana/Indianapolis",
+    "automergeType": "branch",
+    "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+    "semanticCommits": "enabled",
+
+    "assignees": ["kdkasad"],
+    "reviewers": ["kdkasad"],
+
+    "enabledManagers": ["github-actions", "custom.jsonata", "cargo"],
     "customManagers": [
         {
             "customType": "jsonata",
@@ -11,6 +21,27 @@
             "depNameTemplate": "rust-lang/rust",
             "versioningTemplate": "semver-coerced",
             "matchStrings": ["{\"currentValue\": $.toolchain.channel}"]
+        }
+    ],
+
+    "packageRules": [
+        {
+            "description": "Schedule Cargo updates for Friday/Saturday",
+            "matchManagers": ["cargo"],
+            "schedule": "* 8-23 * * 5,6"
+        },
+        {
+            "description": "Auto-merge patch version updates to Cargo dependencies if they pass CI",
+            "matchManagers": ["cargo"],
+            "matchUpdateTypes": ["patch"],
+            "automerge": true
+        },
+        {
+            "description": "Group minor version updates to Cargo dependencies",
+            "matchManagers": ["cargo"],
+            "matchUpdateTypes": ["minor"],
+            "matchCurrentVersion": "!/^0\\./",
+            "groupName": "Cargo (minor)"
         }
     ]
 }


### PR DESCRIPTION
Uses Renovate to check for updates to Cargo dependencies, auto-merging trivial updates to reduce noise.