### PR TITLE
fix: show info message for intentional panic routes

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -102,7 +102,7 @@ pub fn create_router(static_dir: &Path) -> Router<Arc<Webring>> {
         .route(
             "/debug/panic",
             get(async || -> () {
-                panic!();
+                panic!("intentional panic to showcase public error page");
             }),
         )
         .fallback_service(HandlerWithoutStateExt::into_service(


### PR DESCRIPTION
This adds a little message for our intentional panicking route so that it reassures sysadmins that monitor our server logs