### PR TITLE
CI job for updating `flake.lock`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Check out sources
         uses: actions/checkout@v6
         with:
-          sparse-checkout: ci/ssh
+          sparse-checkout: ci
 
       - name: Configure SSH
         env:
@@ -228,7 +228,17 @@ jobs:
           chmod -R u=rwX,g=,o= ~/.ssh
 
       - name: Build on Vulcan
+        id: build
+        continue-on-error: true
         run: ssh vulcan nix build "github:${{ github.repository }}/${{ github.sha }}"
 
+      - name: Update flake.lock
+        if: steps.build.outcome == 'failure'
+        env:
+          FLAKE_URL: github:${{ github.repository }}/${{ github.sha }}
+          LOCKFILE: /tmp/webring-flake-${{ github.run_id }}-${{ github.run_attempt }}.lock
+        run: ./ci/update-flake-lock.sh
+
       - name: Deploy on Vulcan
+        if: steps.build.outcome == 'success'
         run: ssh vulcan home-manager switch --flake "github:${{ github.repository }}/${{ github.sha }}"

--- a/ci/update-flake-lock.sh
+++ b/ci/update-flake-lock.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Updating flake.lock"
+ssh vulcan nix flake update --flake "$FLAKE_URL" --output-lock-file "$LOCKFILE"
+
+echo "Trying to build with the new lockfile"
+# `set -e` will cause this script to fail if the build fails, acting as a guard clause
+ssh vulcan nix build "$FLAKE_URL" --reference-lock-file "$LOCKFILE"
+
+echo "Pushing new lockfile. Deployment will re-run on the new commit."
+scp vulcan:"$LOCKFILE" flake.lock
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+git add flake.lock
+git commit -m "chore: update flake.lock"
+
+git push origin master

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,12 @@
           ];
         };
 
+        # Use pinned rust version for deployment
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = rust;
+          cargo = rust;
+        };
+
         cargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       in
       rec {
@@ -81,7 +87,7 @@
           RUSTC_WRAPPER = "sccache";
         };
 
-        packages.phwebring = pkgs.rustPlatform.buildRustPackage {
+        packages.phwebring = rustPlatform.buildRustPackage {
           pname = cargo.package.name;
           version = cargo.package.version;
 


### PR DESCRIPTION
If building the webring fails due to the `flake.lock` falling out of date, the deploy script will attempt to update the flake and see whether that fixes the build issue. If so, it will push the updated `flake.lock` to master.

This also makes the nix build use the pinned rust version in `rust-toolchain.toml`. Using the pinned rust version wouldn't work without the ability to automatically update the lockfile.