### PR TITLE
Make it open a PR instead

### DIFF
--- a/ci/update-flake-lock.sh
+++ b/ci/update-flake-lock.sh
@@ -14,7 +14,10 @@ scp vulcan:"$LOCKFILE" flake.lock
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
+git branch -d update-flake || true
+git switch -c update-flake
+
 git add flake.lock
 git commit -m "chore: update flake.lock"
 
-git push origin master
+gh pr create -B master -H update-flake --title "Update flake.lock" --body "Deployment is broken due to an outdated flake"


### PR DESCRIPTION
Giving actions push-to-main perms lets anyone open a PR with a new workflow, run it, and push stuff to main