### PR TITLE
Test fixes

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -589,8 +589,7 @@ mod tests {
             [members]
             henry = {{ url = "hrovnyak.gitlab.io", discord-id = 123, check-level = "none" }}
             kian = {{ url = "kasad.com", discord-id = 456, check-level = "none" }}
-            cynthia = {{ url = "https://clementine.viridian.page", discord-id = 789, check-level = "none" }}
-            "???" = {{ url = "ws://refuse-the-r.ing", check-level = "none" }}
+            ericswpark = {{ url = "https://ericswpark.com", discord-id = 789, check-level = "none" }}
         "# }, static_dir.path().display())).unwrap();
         let webring = Arc::new(Webring::new(&config));
         let router: Router = create_router(static_dir.path()).with_state(Arc::clone(&webring));
@@ -672,7 +671,7 @@ mod tests {
         let res = router
             .oneshot(
                 Request::builder()
-                    .uri("/visit?member=clementine.viridian.page")
+                    .uri("/visit?member=kasad.com")
                     .extension(ConnectInfo("5.4.3.2:80".parse::<SocketAddr>().unwrap()))
                     .body(Body::empty())
                     .unwrap(),
@@ -681,14 +680,14 @@ mod tests {
             .unwrap();
         assert_eq!(
             res.headers().get("location").unwrap(),
-            "https://clementine.viridian.page/"
+            "kasad.com"
         );
         assert_eq!(res.status(), StatusCode::SEE_OTHER);
         webring.assert_stat_entry(
             (
                 today,
                 "ring.purduehackers.com",
-                "clementine.viridian.page",
+                "kasad.com",
                 "ring.purduehackers.com",
             ),
             1,
@@ -723,7 +722,7 @@ mod tests {
         let res = router
             .oneshot(
                 Request::builder()
-                    .uri("/next?host=clementine.viridian.page")
+                    .uri("/next?host=kasad.com")
                     .extension(ConnectInfo("5.4.3.2:80".parse::<SocketAddr>().unwrap()))
                     .body(Body::empty())
                     .unwrap(),
@@ -732,7 +731,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             res.headers().get("location").unwrap(),
-            "ws://refuse-the-r.ing/"
+            "https://ericswpark.com/"
         );
         assert_eq!(res.status(), StatusCode::SEE_OTHER);
 
@@ -746,7 +745,7 @@ mod tests {
         let res = router
             .oneshot(
                 Request::builder()
-                    .uri("/prev?host=https://clementine.viridian.page")
+                    .uri("/prev?host=https://ericswpark.com")
                     .header("Referer", "kasad.com")
                     .extension(ConnectInfo("5.4.3.2:80".parse::<SocketAddr>().unwrap()))
                     .body(Body::empty())

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -580,6 +580,7 @@ mod tests {
         fs::write(static_dir.path().join("index.html"), "Hello homepage!")
             .await
             .unwrap();
+        
         let config = toml::from_str(&format!(indoc! { r#"
             [webring]
             base-url = "https://ring.purduehackers.com"
@@ -590,7 +591,7 @@ mod tests {
             henry = {{ url = "hrovnyak.gitlab.io", discord-id = 123, check-level = "none" }}
             kian = {{ url = "kasad.com", discord-id = 456, check-level = "none" }}
             ericswpark = {{ url = "https://ericswpark.com", discord-id = 789, check-level = "none" }}
-        "# }, static_dir.path().display())).unwrap();
+        "# }, static_dir.path().to_string_lossy().escape_default())).unwrap();
         let webring = Arc::new(Webring::new(&config));
         let router: Router = create_router(static_dir.path()).with_state(Arc::clone(&webring));
         (router, webring, static_dir)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -580,8 +580,9 @@ mod tests {
         fs::write(static_dir.path().join("index.html"), "Hello homepage!")
             .await
             .unwrap();
-        
-        let config = toml::from_str(&format!(indoc! { r#"
+
+        let config = toml::from_str(&format!(
+            indoc! { r#"
             [webring]
             base-url = "https://ring.purduehackers.com"
             static-dir = "{}"
@@ -679,10 +680,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(
-            res.headers().get("location").unwrap(),
-            "kasad.com"
-        );
+        assert_eq!(res.headers().get("location").unwrap(), "kasad.com");
         assert_eq!(res.status(), StatusCode::SEE_OTHER);
         webring.assert_stat_entry(
             (

--- a/src/webring.rs
+++ b/src/webring.rs
@@ -779,7 +779,7 @@ mod tests {
                 cynthia = {{ url = "https://localhost:32751", discord-id = 789, check-level = "online" }}
                 "???" = {{ url = "ws://refuse-the-r.ing", check-level = "none" }}
             "# },
-            static_dir.path().display()
+            static_dir.path().to_string_lossy().escape_default()
         ))
         .unwrap()
     }
@@ -1106,7 +1106,7 @@ mod tests {
             network.listen-addr = "0.0.0.0:3000"
             members.kian = {{ url = "https://kasad.com", check-level = "none" }}
         "# },
-            static_dir.path().display()
+            static_dir.path().to_string_lossy().escape_default()
         )
         .unwrap();
         config_file.flush().unwrap();


### PR DESCRIPTION
- Removed old references following sample `webring.toml` changes
- Fixed test paths not working under Windows due to `\`